### PR TITLE
Merge cms-indexing module into this one

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>se.simonsoft</groupId>
-			<artifactId>cms-indexing</artifactId>
+			<artifactId>repos-indexing</artifactId>
 			<version>0.12.1</version>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 	
 	<dependencies>
 		<dependency>
-			<groupId>se.simonsoft</groupId>
+			<groupId>se.repos</groupId>
 			<artifactId>repos-indexing</artifactId>
 			<version>0.12.1</version>
 		</dependency>

--- a/src/main/java/se/simonsoft/cms/indexing/abx/HandlerAbxDependencies.java
+++ b/src/main/java/se/simonsoft/cms/indexing/abx/HandlerAbxDependencies.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2009-2013 Simonsoft Nordic AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.simonsoft.cms.indexing.abx;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import se.repos.indexing.IndexingHandlerException;
+import se.repos.indexing.IndexingDoc;
+import se.repos.indexing.IndexingItemHandler;
+import se.repos.indexing.item.HandlerPathinfo;
+import se.repos.indexing.item.IndexingItemProgress;
+import se.repos.indexing.item.HandlerProperties;
+import se.simonsoft.cms.item.CmsItemId;
+import se.simonsoft.cms.item.RepoRevision;
+import se.simonsoft.cms.item.impl.CmsItemIdArg;
+import se.simonsoft.cms.item.indexing.IdStrategy;
+
+/**
+ * Uses the abx:Dependencies and abx:CrossRefs properties splitting on newline.
+ */
+public class HandlerAbxDependencies extends HandlerAbxFolders {
+
+	private static final Logger logger = LoggerFactory.getLogger(HandlerAbxDependencies.class);
+	
+	private static final String HOSTFIELD = "repohost";
+	
+	/**
+	 * @param idStrategy to fill the refid field
+	 */
+	@Inject
+	public HandlerAbxDependencies(IdStrategy idStrategy) {
+		super(idStrategy);
+	}
+	
+	@Override
+	public void handle(IndexingItemProgress progress) {
+		IndexingDoc fields = progress.getFields();
+		String host = (String) fields.getFieldValue(HOSTFIELD);
+		if (host == null) {
+			throw new IllegalStateException("Depending on indexer that adds host field " + HOSTFIELD);
+		}
+		String[] abxProperties = {"abx.Dependencies", "abx.CrossRefs"};
+		
+		Set<CmsItemId> dependencyIds = new HashSet<CmsItemId>();
+		for (String propertyName : abxProperties) {
+			try {
+				dependencyIds.addAll(handleAbxProperty(fields, host, propertyName, (String) fields.getFieldValue("prop_" + propertyName)));
+			} catch (Exception e) {
+				logger.warn("Failed to parse {}: {}", propertyName, e.getMessage(), e);
+				throw new IndexingHandlerException("Failed to parse " + propertyName + ": " + e.getMessage(), e);
+			}
+		}
+		
+		String refId;
+		for (CmsItemId depItemId : dependencyIds) {
+			
+			refId = depItemId.getPegRev() == null ?
+					idStrategy.getIdHead(depItemId) :
+					idStrategy.getId(depItemId, new RepoRevision(depItemId.getPegRev(), null));
+			
+			fields.addField("refid", refId);
+			
+		}
+		
+		handleFolders(fields, "ref_pathparents", dependencyIds);
+		
+	}
+
+	@Override
+	public Set<Class<? extends IndexingItemHandler>> getDependencies() {
+		return new HashSet<Class<? extends IndexingItemHandler>>() {private static final long serialVersionUID = 1L;{
+			add(HandlerPathinfo.class);
+			add(HandlerProperties.class);
+		}};
+	}
+	
+	protected Set<CmsItemId> handleAbxProperty(IndexingDoc fields, String host, String propertyName, String abxprop) {
+
+		Set<CmsItemId> result = new HashSet<CmsItemId>();
+
+		if (abxprop != null) {
+			
+			if (abxprop.length() != 0) {
+				
+				String strategyId;
+				
+				for (String d : abxprop.split("\n")) {
+					CmsItemIdArg id = new CmsItemIdArg(d);
+					id.setHostname(host);
+					
+					strategyId = id.getPegRev() != null ?
+							idStrategy.getId(id, new RepoRevision(id.getPegRev(), null)) :
+							idStrategy.getIdHead(id);
+					
+					fields.addField("ref_" + propertyName, strategyId);
+					
+					result.add(id);
+				}
+				
+			} else {
+				logger.debug("{} property exists but is empty", propertyName);
+			}
+			
+		}
+		
+		return result;
+
+	}
+
+}

--- a/src/main/java/se/simonsoft/cms/indexing/abx/HandlerAbxFolders.java
+++ b/src/main/java/se/simonsoft/cms/indexing/abx/HandlerAbxFolders.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (C) 2009-2013 Simonsoft Nordic AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.simonsoft.cms.indexing.abx;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.inject.Inject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import se.repos.indexing.IndexingDoc;
+import se.repos.indexing.IndexingItemHandler;
+import se.simonsoft.cms.item.CmsItemId;
+import se.simonsoft.cms.item.CmsItemPath;
+import se.simonsoft.cms.item.RepoRevision;
+import se.simonsoft.cms.item.indexing.IdStrategy;
+
+public abstract class HandlerAbxFolders implements IndexingItemHandler {
+
+	private static final Logger logger = LoggerFactory.getLogger(HandlerAbxFolders.class);
+	
+	protected final IdStrategy idStrategy;
+	
+	@Inject
+	public HandlerAbxFolders(IdStrategy idStrategy) {
+		this.idStrategy = idStrategy;
+	}
+	
+	/**
+	 * Takes a set of unique CmsItemId's and filters out unique parent paths
+	 * before adding them to the provided folderField.
+	 *
+	 * @param fields
+	 * @param folderField
+	 * @param ids Set of CmsItemIdBase since we need to know they are unique
+	 * @return 
+	 */
+	protected IndexingDoc handleFolders(IndexingDoc fields, String folderField, Set<CmsItemId> ids) {
+
+		if (ids != null) {
+			
+			Set<String> parentPaths = new HashSet<String>();
+			String tempPath;
+			RepoRevision revision;
+			
+			for (CmsItemId id : ids) {
+				
+				for (CmsItemPath ancestor : id.getRelPath().getAncestors()) {
+					
+					revision = id.getPegRev() != null ? new RepoRevision(id.getPegRev(), null) : null;
+					tempPath = revision != null ? idStrategy.getId(id.getRepository(), revision, ancestor) : idStrategy.getIdHead(id.getRepository(), ancestor);
+					
+					if (!parentPaths.add(tempPath)) {
+						logger.trace("Ignored {} from {} as it already exists in the set.", ancestor, id);
+					}
+				}
+				
+			}
+			
+			for (String path : parentPaths) {
+				fields.addField(folderField, path);
+			}
+			
+		}
+		
+		return fields;
+		
+	}
+
+}

--- a/src/main/java/se/simonsoft/cms/indexing/abx/HandlerAbxMasters.java
+++ b/src/main/java/se/simonsoft/cms/indexing/abx/HandlerAbxMasters.java
@@ -1,0 +1,132 @@
+/**
+ * Copyright (C) 2009-2013 Simonsoft Nordic AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.simonsoft.cms.indexing.abx;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import se.simonsoft.cms.item.indexing.IdStrategy;
+import se.repos.indexing.IndexingDoc;
+import se.repos.indexing.IndexingItemHandler;
+import se.repos.indexing.item.HandlerPathinfo;
+import se.repos.indexing.item.IndexingItemProgress;
+import se.repos.indexing.item.HandlerProperties;
+import se.simonsoft.cms.item.CmsItemId;
+import se.simonsoft.cms.item.RepoRevision;
+import se.simonsoft.cms.item.impl.CmsItemIdArg;
+
+/**
+ * Uses the abx.*Master properties, splitting on newline, to add fields rel_abx.*Master.
+ */
+public class HandlerAbxMasters extends HandlerAbxFolders {
+
+	private static final Logger logger = LoggerFactory.getLogger(HandlerAbxMasters.class);
+	
+	private static final String HOSTFIELD = "repohost";
+	
+	/**
+	 * @param idStrategy to fill the refid/relid field
+	 */
+	@Inject
+	public HandlerAbxMasters(IdStrategy idStrategy) {
+		super(idStrategy);
+	}
+	
+	@Override
+	public void handle(IndexingItemProgress progress) {
+		
+		logger.trace("handle(IndexItemProgress progress)");
+		
+		IndexingDoc fields = progress.getFields();
+		String host = (String) fields.getFieldValue(HOSTFIELD);
+		if (host == null) {
+			throw new IllegalStateException("Depending on indexer that adds host field " + HOSTFIELD);
+		}
+		
+		Set<CmsItemId> masterIds = new HashSet<CmsItemId>();
+		String[] abxProperties = {"abx.ReleaseMaster", "abx.AuthorMaster", "abx.TranslationMaster"};
+		for (String propertyName : abxProperties) {
+			masterIds.addAll(handleAbxProperty(fields, host, propertyName, (String) fields.getFieldValue("prop_" + propertyName)));
+		}
+		
+		for (CmsItemId masterId : masterIds) {
+			fields.addField("rel_abx.Masters", 
+					masterId.getPegRev() == null ? 
+							idStrategy.getIdHead(masterId) : 
+							idStrategy.getId(masterId, new RepoRevision(masterId.getPegRev(), null)));
+		}
+		
+		handleFolders(fields, "rel_abx.Masters_pathparents", masterIds);
+		
+	}
+
+	@Override
+	public Set<Class<? extends IndexingItemHandler>> getDependencies() {
+		return new HashSet<Class<? extends IndexingItemHandler>>() {private static final long serialVersionUID = 1L;{
+			add(HandlerPathinfo.class);
+			add(HandlerProperties.class);
+		}};
+	}
+	
+	/**
+	 * Helper method for extracting master ids and adding them to a reference
+	 * field. Assumes that the provided property is found in a field with the
+	 * prefix "prop_".
+	 *
+	 * @param fields
+	 * @param host
+	 * @param propertyName name of the property field to copy master ref from
+	 * @param abxprop value of the property field.
+	 * @return 
+	 */
+	protected Set<CmsItemId> handleAbxProperty(IndexingDoc fields, String host, String propertyName, String abxprop) {
+
+		Set<CmsItemId> result = new HashSet<CmsItemId>();
+
+		String strategyId;
+		if (abxprop != null) {
+			
+			if (abxprop.length() != 0) {
+				
+				for (String d : abxprop.split("\n")) {
+					CmsItemIdArg id = new CmsItemIdArg(d);
+					id.setHostname(host);
+					
+					strategyId = id.getPegRev() != null ?
+							idStrategy.getId(id, new RepoRevision(id.getPegRev(), null)) :
+							idStrategy.getIdHead(id);
+					
+					fields.addField("rel_" + propertyName, strategyId);
+					
+					result.add(id);
+				}
+				
+			} else {
+				logger.debug("{} property exists but is empty", propertyName);
+			}
+			
+		}
+		
+		return result;
+		
+	}
+
+}

--- a/src/main/java/se/simonsoft/cms/indexing/abx/HandlerLogicalId.java
+++ b/src/main/java/se/simonsoft/cms/indexing/abx/HandlerLogicalId.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (C) 2009-2013 Simonsoft Nordic AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.simonsoft.cms.indexing.abx;
+
+import se.repos.indexing.IndexingItemHandler;
+import se.repos.indexing.item.IndexingItemProgress;
+import se.simonsoft.cms.item.CmsItemId;
+
+/**
+ * Sets the {@value #FIELD_NAME} field.
+ */
+public abstract class HandlerLogicalId implements IndexingItemHandler {
+
+	public static final String FIELD_NAME = "urlid";
+	
+	@Override
+	public void handle(IndexingItemProgress progress) {
+		CmsItemId itemId = getItemId(progress);
+		if (itemId != null) {
+			// use addField istead of setField so we detect conflicts with other id resolution strategies
+			progress.getFields().addField(FIELD_NAME, itemId.getLogicalIdFull());
+		}
+	}
+	
+	/**
+	 * @param progress from {@link #handle(IndexingItemProgress)}
+	 * @return null to avoid setting the field, an id preferably with peg rev to set the field
+	 */
+	protected abstract CmsItemId getItemId(IndexingItemProgress progress);
+
+}

--- a/src/main/java/se/simonsoft/cms/indexing/abx/HandlerLogicalIdFromUrl.java
+++ b/src/main/java/se/simonsoft/cms/indexing/abx/HandlerLogicalIdFromUrl.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2009-2013 Simonsoft Nordic AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.simonsoft.cms.indexing.abx;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import se.repos.indexing.IndexingItemHandler;
+import se.repos.indexing.item.HandlerPathinfo;
+import se.repos.indexing.item.HandlerProperties;
+import se.repos.indexing.item.IndexingItemProgress;
+import se.simonsoft.cms.item.CmsItemId;
+import se.simonsoft.cms.item.CmsRepository;
+import se.simonsoft.cms.item.events.change.CmsChangesetItem;
+
+/**
+ * Without cms-logicalid module we can't encode a logical id based on {@link CmsChangesetItem},
+ * so we'll use the URL as specified by repos-indexing, using the assumption that the URL
+ * is encoded according to Subversion/SvnKit standards.
+ */
+public class HandlerLogicalIdFromUrl extends HandlerLogicalId {
+	
+	public static final String URL_ITEM_FIELD = "url";
+	public static final String REV_ITEM_FIELD = "rev";
+	
+	@Override
+	protected CmsItemId getItemId(IndexingItemProgress progress) {
+		CmsChangesetItem item = progress.getItem();
+		CmsRepository repo = progress.getRepository();
+		if (repo.getHost() == null) {
+			throw new AssertionError("Missing host information for " + item + ", can not set logical ID");
+		}
+		String url = (String) progress.getFields().getFieldValue(URL_ITEM_FIELD);
+		if (url == null) {
+			throw new AssertionError("Missing " + URL_ITEM_FIELD + " field for " + item + ", can not set logical ID");
+		}
+
+		Long rev = (Long) progress.getFields().getFieldValue(REV_ITEM_FIELD); // should be path revision
+		CmsItemId id = repo.getItemId(url).withPegRev(rev);
+		return id;
+	}
+	
+	@SuppressWarnings("serial")
+	@Override
+	public Set<Class<? extends IndexingItemHandler>> getDependencies() {
+		return new HashSet<Class<? extends IndexingItemHandler>>() {{
+			add(HandlerPathinfo.class);
+			add(HandlerProperties.class);
+		}};
+	}
+
+}

--- a/src/main/java/se/simonsoft/cms/indexing/abx/HandlerPathareaFromConfig.java
+++ b/src/main/java/se/simonsoft/cms/indexing/abx/HandlerPathareaFromConfig.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (C) 2009-2013 Simonsoft Nordic AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.simonsoft.cms.indexing.abx;
+
+/**
+ * We use ReleasePath and TranslationPath to place new slaves, but no longer to detect if a document is a release or a translation.
+ * Use {@link HandlerPathareaFromProperties} instead.
+ */
+public class HandlerPathareaFromConfig {
+
+	public HandlerPathareaFromConfig() {
+		throw new UnsupportedOperationException("use detection based on properties instead");
+	}
+
+}

--- a/src/main/java/se/simonsoft/cms/indexing/abx/HandlerPathareaFromProperties.java
+++ b/src/main/java/se/simonsoft/cms/indexing/abx/HandlerPathareaFromProperties.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (C) 2009-2013 Simonsoft Nordic AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.simonsoft.cms.indexing.abx;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import se.repos.indexing.IndexingDoc;
+import se.repos.indexing.IndexingItemHandler;
+import se.repos.indexing.item.IndexingItemProgress;
+import se.repos.indexing.item.HandlerProperties;
+
+public class HandlerPathareaFromProperties implements
+		IndexingItemHandler {
+
+	private static final String RELEASE_VAL = "release";
+	private static final String TRANSLATION_VAL = "translation";
+	private static final String TRANSLATION10_VAL = "translation10";
+	
+	private static final String RELEASELABEL_FIELD = "prop_abx.ReleaseLabel";
+	private static final String TRANSLATIONLOCALE_FIELD = "prop_abx.TranslationLocale";
+	
+	private static final String AUTHORMASTER_FIELD = "prop_abx.AuthorMaster";
+	private static final String RELEASEMASTER_FIELD = "prop_abx.ReleaseMaster";
+	private static final String TRANSLATIONMASTER_FIELD = "prop_abx.TranslationMaster";
+
+	@Override
+	public void handle(IndexingItemProgress progress) {
+		IndexingDoc doc = progress.getFields();
+		if (doc.containsKey(TRANSLATIONMASTER_FIELD) || doc.containsKey(TRANSLATIONLOCALE_FIELD)) {
+			doc.setField("pathmain", false);
+			if (doc.containsKey(AUTHORMASTER_FIELD) || doc.containsKey(TRANSLATIONLOCALE_FIELD)) 
+				doc.addField("patharea", TRANSLATION_VAL);
+			else
+				doc.addField("patharea", TRANSLATION10_VAL); // In CMS 1.0, there were neither AM or TL fields.
+			
+		} else if (doc.containsKey(RELEASEMASTER_FIELD) || doc.containsKey(RELEASELABEL_FIELD)) {
+			doc.addField("patharea", RELEASE_VAL);
+			doc.setField("pathmain", false);
+		} else {
+			doc.setField("pathmain", true);
+		}
+	}
+
+	@SuppressWarnings("serial")
+	@Override
+	public Set<Class<? extends IndexingItemHandler>> getDependencies() {
+		return new HashSet<Class<? extends IndexingItemHandler>>() {{
+			add(HandlerProperties.class);
+		}};
+	}
+
+}

--- a/src/main/java/se/simonsoft/cms/indexing/abx/HandlerTextSelection.java
+++ b/src/main/java/se/simonsoft/cms/indexing/abx/HandlerTextSelection.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright (C) 2009-2013 Simonsoft Nordic AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.simonsoft.cms.indexing.abx;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import se.repos.indexing.IndexingDoc;
+import se.repos.indexing.IndexingItemHandler;
+import se.repos.indexing.item.HandlerPathinfo;
+import se.repos.indexing.item.HandlerProperties;
+import se.repos.indexing.item.IndexingItemProgress;
+
+public class HandlerTextSelection implements IndexingItemHandler{
+
+	private static final String TEXT_FIELD = "text";
+	private static final Logger logger = LoggerFactory.getLogger(HandlerTextSelection.class);
+	private Set<String> fields = new LinkedHashSet<String>();
+	/***
+	 * Constructor populates a set with possible title properties keys.
+	 */
+	public HandlerTextSelection() {
+		super();
+		fields.add("embd_xml_textX"); // cms-indexing-xml
+	}
+
+	/***
+	 * Looks after possible text values with given keys. The first hit will be indexed.
+	 * The order of the set decides the priority.
+	 * Fallback is the Tika field already placed in 'text' field by repos-indexing-fulltext.
+	 */
+	@Override
+	public void handle(IndexingItemProgress progress) {
+		IndexingDoc doc = progress.getFields();
+		
+		// TODO: Remove all fulltext search if head:false, see repos-indexing-fulltext.
+		
+		for(String key: this.fields) {
+			if(doc.containsKey(key)){
+			 	String value = doc.getFieldValues(key).iterator().next().toString();
+				if(value != null && !value.trim().equals("")) {
+					doc.setField(TEXT_FIELD, value);
+					logger.info("Indexing value from {}", key);
+					break;
+				}
+			}
+		}
+		
+		// Removing the temporary text fields, might be large.
+		for(String key: this.fields) {
+			doc.removeField(key);
+		}
+		
+	}
+
+	@SuppressWarnings("serial")
+	@Override
+	public Set<Class<? extends IndexingItemHandler>> getDependencies() {
+		return new HashSet<Class<? extends IndexingItemHandler>>() {{
+			add(HandlerPathinfo.class);
+			add(HandlerProperties.class);
+		}};
+	}
+
+
+}

--- a/src/main/java/se/simonsoft/cms/indexing/abx/HandlerTitleSelection.java
+++ b/src/main/java/se/simonsoft/cms/indexing/abx/HandlerTitleSelection.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2009-2013 Simonsoft Nordic AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.simonsoft.cms.indexing.abx;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import se.repos.indexing.IndexingDoc;
+import se.repos.indexing.IndexingItemHandler;
+import se.repos.indexing.item.HandlerPathinfo;
+import se.repos.indexing.item.HandlerProperties;
+import se.repos.indexing.item.IndexingItemProgress;
+
+public class HandlerTitleSelection implements IndexingItemHandler{
+
+	private static final String TITLE_FIELD = "title";
+	private static final Logger logger = LoggerFactory.getLogger(HandlerTitleSelection.class);
+	private Set<String> fieldTitleKeys = new LinkedHashSet<String>();
+	/***
+	 * Constructor populates a set with possible title properties keys.
+	 */
+	public HandlerTitleSelection() {
+		super();
+		fieldTitleKeys.add("prop_cms.title");
+		fieldTitleKeys.add("embd_xml_title"); // cms-indexing-xml
+		fieldTitleKeys.add("embd_title"); // Tika
+		fieldTitleKeys.add("xmp_dc.title");
+		fieldTitleKeys.add("xmp_dc.subject");
+		fieldTitleKeys.add("xmp_dc.description");
+	}
+
+	/***
+	 * Looks after possible title values with given keys. The first hit will be indexed.
+	 * The order of the set decides the priority.
+	 */
+	@Override
+	public void handle(IndexingItemProgress progress) {
+		IndexingDoc doc = progress.getFields();
+		
+		for(String key: this.fieldTitleKeys) {
+			if(doc.containsKey(key)){
+			 	String value = doc.getFieldValues(key).iterator().next().toString();
+				if(value != null && !value.trim().equals("")) {
+					doc.setField(TITLE_FIELD, value);
+					logger.info("Indexing value from {}: \"{}\"", key, value);
+					break;
+				}
+			}
+		}
+	}
+
+	@SuppressWarnings("serial")
+	@Override
+	public Set<Class<? extends IndexingItemHandler>> getDependencies() {
+		return new HashSet<Class<? extends IndexingItemHandler>>() {{
+			add(HandlerPathinfo.class);
+			add(HandlerProperties.class);
+		}};
+	}
+
+}

--- a/src/test/java/se/simonsoft/cms/indexing/abx/HandlerAbxDependenciesTest.java
+++ b/src/test/java/se/simonsoft/cms/indexing/abx/HandlerAbxDependenciesTest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (C) 2009-2013 Simonsoft Nordic AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.simonsoft.cms.indexing.abx;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Collection;
+
+import org.junit.Test;
+
+import se.repos.indexing.IndexingHandlerException;
+import se.repos.indexing.IndexingDoc;
+import se.repos.indexing.IndexingItemHandler;
+import se.simonsoft.cms.item.indexing.IdStrategyDefault;
+import se.repos.indexing.item.IndexingItemProgress;
+import se.repos.indexing.twophases.IndexingDocIncrementalSolrj;
+import se.simonsoft.cms.item.CmsRepository;
+
+public class HandlerAbxDependenciesTest {
+
+	@Test
+	public void test() {
+		String abxdeps = "x-svn:///svn/documentation^/graphics/cms/process/2.0/op-edit.png\n" +
+				"x-svn:///svn/documentation^/xml/reference/cms/adapter/Introduction%20to%20CMS.xml\n" +
+				"x-svn:///svn/documentation^/xml/reference/cms/User_interface.xml?p=123";
+		IndexingItemProgress p = mock(IndexingItemProgress.class);
+		IndexingDoc doc = new IndexingDocIncrementalSolrj();
+		when(p.getFields()).thenReturn(doc);
+		when(p.getRepository()).thenReturn(new CmsRepository("http://host:123/svn/documentation"));
+		doc.addField("repohost", "host:123");
+		doc.addField("prop_abx.Dependencies", abxdeps);
+		doc.addField("ref_link", "/existing/url/");
+		
+		IndexingItemHandler handler = new HandlerAbxDependencies(new IdStrategyDefault());
+		handler.handle(p);
+		Collection<Object> refid = doc.getFieldValues("ref_abx.Dependencies");
+		assertEquals("Should have added the dependencies as refid", 3, refid.size());
+		assertTrue(refid.contains("host:123/svn/documentation/graphics/cms/process/2.0/op-edit.png"));
+		assertTrue(refid.contains("host:123/svn/documentation/xml/reference/cms/adapter/Introduction%20to%20CMS.xml"));
+		assertTrue(refid.contains("host:123/svn/documentation/xml/reference/cms/User_interface.xml@0000000123"));
+		assertFalse("Revision-locked dependencies are irrelevant in the typical 'where used' use case, don't get false positives when using idhead search/join",
+				refid.contains("host:123/svn/documentation/xml/reference/cms/User_interface.xml"));
+		
+	}
+	
+	@Test
+	public void testInvalid() {
+		String abxdeps = "x-svn:///svn/documentation^/graphics/cms/process/2.0/in valid.png\n" + // Incorrectly accepted.
+				"invalid.png\n" + // Unfortunately needed to trigger the issue.
+				"x-svn:///svn/documentation^/xml/reference/cms/adapter/Introduction%20to%20CMS.xml\n" +
+				"x-svn:///svn/documentation^/xml/reference/cms/User_interface.xml?p=123";
+		IndexingItemProgress p = mock(IndexingItemProgress.class);
+		IndexingDoc doc = new IndexingDocIncrementalSolrj();
+		when(p.getFields()).thenReturn(doc);
+		when(p.getRepository()).thenReturn(new CmsRepository("http://host:123/svn/documentation"));
+		doc.addField("repohost", "host:123");
+		doc.addField("prop_abx.Dependencies", abxdeps);
+		doc.addField("ref_link", "/existing/url/");
+		
+		IndexingItemHandler handler = new HandlerAbxDependencies(new IdStrategyDefault());
+		try {
+			handler.handle(p);
+			fail("Expected HandlerException in handler.");
+		} catch (IndexingHandlerException ex) {
+			// expected
+			assertTrue(ex.getMessage().startsWith("Failed to parse abx.Dependencies"));
+		}
+		Collection<Object> refid = doc.getFieldValues("ref_abx.Dependencies");
+		assertEquals("Should have failed to add the dependencies as refid", 1, refid.size()); // Should really be zero.
+		
+	}
+	
+	@Test
+	public void testAggregatedDependenciesOnly() {
+		String abxdeps = "x-svn:///svn/documentation^/graphics/cms/process/2.0/op-edit.png\n" +
+				"x-svn:///svn/documentation^/xml/reference/cms/adapter/Introduction%20to%20CMS.xml\n" +
+				"x-svn:///svn/documentation^/xml/reference/cms/User_interface.xml?p=123";
+		IndexingItemProgress p = mock(IndexingItemProgress.class);
+		IndexingDoc doc = new IndexingDocIncrementalSolrj();
+		when(p.getFields()).thenReturn(doc);
+		when(p.getRepository()).thenReturn(new CmsRepository("http://host:123/svn/documentation"));
+		doc.addField("repohost", "host:123");
+		doc.addField("prop_abx.Dependencies", abxdeps);
+		doc.addField("ref_link", "/existing/url/");
+		
+		IndexingItemHandler handler = new HandlerAbxDependencies(new IdStrategyDefault());
+		handler.handle(p);
+		Collection<Object> refid = doc.getFieldValues("refid");
+		assertEquals("Should have added the dependencies as refid", 3, refid.size());
+		assertTrue(refid.contains("host:123/svn/documentation/graphics/cms/process/2.0/op-edit.png"));
+		assertTrue(refid.contains("host:123/svn/documentation/xml/reference/cms/adapter/Introduction%20to%20CMS.xml"));
+		assertTrue(refid.contains("host:123/svn/documentation/xml/reference/cms/User_interface.xml@0000000123"));
+		assertFalse("Revision-locked dependencies are irrelevant in the typical 'where used' use case, don't get false positives when using idhead search/join",
+				refid.contains("host:123/svn/documentation/xml/reference/cms/User_interface.xml"));
+		
+		// pathparents are tested in HandlerAbxFoldersTest.java
+	}
+	
+	@Test
+	public void testAggregated() {
+		String abxdeps = "x-svn:///svn/documentation^/graphics/cms/process/2.0/op-edit.png\n";
+		String abxcross = "x-svn:///svn/documentation^/xml/reference/cms/adapter/Introduction%20to%20CMS.xml\n";
+		IndexingItemProgress p = mock(IndexingItemProgress.class);
+		IndexingDoc doc = new IndexingDocIncrementalSolrj();
+		when(p.getFields()).thenReturn(doc);
+		when(p.getRepository()).thenReturn(new CmsRepository("http://host:123/svn/documentation"));
+		doc.addField("repohost", "host:123");
+		doc.addField("prop_abx.Dependencies", abxdeps);
+		doc.addField("prop_abx.CrossRefs", abxcross);
+		doc.addField("ref_link", "/existing/url/");
+		doc.addField("refid", "host:123/existing/url/");
+		
+		IndexingItemHandler handler = new HandlerAbxDependencies(new IdStrategyDefault());
+		handler.handle(p);
+		Collection<Object> refdep = doc.getFieldValues("ref_abx.Dependencies");
+		Collection<Object> refcross = doc.getFieldValues("ref_abx.CrossRefs");
+		
+		assertEquals("Should have added the dependency as refdep", 1, refdep.size());
+		assertTrue(refdep.contains("host:123/svn/documentation/graphics/cms/process/2.0/op-edit.png"));
+		assertTrue(refcross.contains("host:123/svn/documentation/xml/reference/cms/adapter/Introduction%20to%20CMS.xml"));
+		
+		Collection<Object> refid = doc.getFieldValues("refid");
+		assertEquals("Should have aggregated references in refid and kept existing", 3, refid.size());
+
+		Collection<Object> refpathparents = doc.getFieldValues("ref_pathparents");
+		assertEquals("Should have aggregated references pathparents", 8, refpathparents.size()); //guessing the number
+
+	}
+
+
+}

--- a/src/test/java/se/simonsoft/cms/indexing/abx/HandlerAbxFoldersTest.java
+++ b/src/test/java/se/simonsoft/cms/indexing/abx/HandlerAbxFoldersTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright (C) 2009-2013 Simonsoft Nordic AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.simonsoft.cms.indexing.abx;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+
+import se.repos.indexing.IndexingDoc;
+import se.repos.indexing.IndexingItemHandler;
+import se.simonsoft.cms.item.indexing.IdStrategyDefault;
+import se.repos.indexing.item.IndexingItemProgress;
+import se.repos.indexing.twophases.IndexingDocIncrementalSolrj;
+import se.simonsoft.cms.item.CmsRepository;
+
+/**
+ *
+ * @author Markus Mattsson
+ */
+public class HandlerAbxFoldersTest {
+	
+	@BeforeClass
+	public static void setUpClass() {
+	}
+	
+	@AfterClass
+	public static void tearDownClass() {
+	}
+	
+	@Before
+	public void setUp() {
+	}
+	
+	@After
+	public void tearDown() {
+	}
+
+	/**
+	 * Testing parent path handling for dependencies.
+	 */
+	@Test
+	public void testHandleDependenciesParents() {
+		
+		String abxdeps = "x-svn:///svn/documentation^/graphics/cms/process/2.0/op-edit.png\n" +
+				"x-svn:///svn/documentation^/xml/reference/cms/adapter/Introduction%20to%20CMS.xml\n" +
+				"x-svn:///svn/documentation^/xml/reference/cms/User_interface.xml?p=123";
+		IndexingItemProgress p = mock(IndexingItemProgress.class);
+		IndexingDoc doc = new IndexingDocIncrementalSolrj();
+		when(p.getFields()).thenReturn(doc);
+		when(p.getRepository()).thenReturn(new CmsRepository("http://host:123/svn/documentation"));
+		doc.addField("repohost", "host:123");
+		doc.addField("prop_abx.Dependencies", abxdeps);
+		doc.addField("ref_link", "/existing/url/");
+		doc.addField("refid", "host:123/existing/url/");
+		
+		IndexingItemHandler handler = new HandlerAbxDependencies(new IdStrategyDefault());
+		handler.handle(p);
+		System.out.println("ref_pathparents: " + doc.getFieldValues("ref_pathparents"));
+		
+		Collection<Object> pathParents = doc.getFieldValues("ref_pathparents");
+		assertEquals("Expected ref_pathparents to be populated.", 11, pathParents.size());
+
+	}
+	
+	/**
+	 * Testing parent path handling for masters.
+	 */
+	@Test
+	public void testHandleMastersParents() {
+		
+		String authorMaster = "x-svn:///svn/demo1^/vvab/xml/documents/900108.xml?p=129";
+		String translationMaster = "x-svn:///svn/demo1^/vvab/release/A/xml/documents/900108.xml?p=131";
+		
+		IndexingItemProgress p = mock(IndexingItemProgress.class);
+		IndexingDoc doc = new IndexingDocIncrementalSolrj();
+		when(p.getFields()).thenReturn(doc);
+		when(p.getRepository()).thenReturn(new CmsRepository("http://host:123/svn/demo1"));
+		doc.addField("repohost", "host:123");
+		doc.addField("prop_abx.AuthorMaster", authorMaster);
+		doc.addField("prop_abx.TranslationMaster", translationMaster);
+		
+		IndexingItemHandler handler = new HandlerAbxMasters(new IdStrategyDefault());
+		handler.handle(p);
+		System.out.println("rel_abx.Masters_pathparents: " + doc.getFieldValues("rel_abx.Masters_pathparents"));
+		
+		Collection<Object> abxMastersPathParents = doc.getFieldValues("rel_abx.Masters_pathparents");
+		
+		assertEquals("Expected rel_abx.Masters_pathparents to be populated.", 8, abxMastersPathParents.size());
+		
+		// Also testing the individual Master fields and aggregated
+		assertEquals(1, doc.getFieldValues("rel_abx.TranslationMaster").size());
+		assertEquals(1, doc.getFieldValues("rel_abx.AuthorMaster").size());
+		
+		assertEquals("Expected rel_abx.Masters to be populated.", 2, doc.getFieldValues("rel_abx.Masters").size());
+		assertTrue(doc.getFieldValues("rel_abx.Masters").contains("host:123/svn/demo1/vvab/release/A/xml/documents/900108.xml@0000000131"));
+		
+	}
+
+}

--- a/src/test/java/se/simonsoft/cms/indexing/abx/HandlerLogicalIdFromUrlTest.java
+++ b/src/test/java/se/simonsoft/cms/indexing/abx/HandlerLogicalIdFromUrlTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (C) 2009-2013 Simonsoft Nordic AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.simonsoft.cms.indexing.abx;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import se.repos.indexing.IndexingDoc;
+import se.repos.indexing.IndexingItemHandler;
+import se.repos.indexing.item.IndexingItemProgress;
+import se.repos.indexing.twophases.IndexingDocIncrementalSolrj;
+import se.simonsoft.cms.item.CmsRepository;
+import se.simonsoft.cms.item.RepoRevision;
+import se.simonsoft.cms.item.events.change.CmsChangesetItem;
+import se.simonsoft.cms.item.impl.CmsItemIdArg;
+
+public class HandlerLogicalIdFromUrlTest {
+
+	@Test
+	public void testHandle() {
+		String logicalId = "x-svn://host:123/svn/documentation^/xml/reference/cms/User%20interface.xml?p=145";
+		String repourl = "http://host:123/svn/documentation";
+		String itemurl = repourl.concat("/xml/reference/cms/User%20interface.xml");
+		IndexingItemProgress p = mock(IndexingItemProgress.class);
+		CmsChangesetItem pi = mock(CmsChangesetItem.class);
+		when(pi.getRevisionChanged()).thenReturn(new RepoRevision(83, null));
+		when(p.getItem()).thenReturn(pi);
+		IndexingDoc doc = new IndexingDocIncrementalSolrj();
+		when(p.getFields()).thenReturn(doc);
+		when(p.getRepository()).thenReturn(new CmsRepository(repourl));
+		doc.addField("url", itemurl);
+		doc.addField("rev", 145L);
+		doc.addField("revc", 83L);
+		
+		IndexingItemHandler handler = new HandlerLogicalIdFromUrl();
+		handler.handle(p);
+		String urlid = (String) doc.getFieldValue("urlid");
+		assertNotNull("Should set field", urlid);
+		CmsItemIdArg id = new CmsItemIdArg(urlid);
+		assertEquals("/xml/reference/cms/User interface.xml", id.getRelPath().getPath());
+		assertEquals("Revision should not be from base but from path rev", new Long(145), id.getPegRev());
+		assertEquals("Logicalid with rev and host", logicalId, id.getLogicalIdFull());
+
+	}
+
+	
+	
+}

--- a/src/test/java/se/simonsoft/cms/indexing/abx/HandlerPathareaFromPropertiesTest.java
+++ b/src/test/java/se/simonsoft/cms/indexing/abx/HandlerPathareaFromPropertiesTest.java
@@ -1,0 +1,135 @@
+/**
+ * Copyright (C) 2009-2013 Simonsoft Nordic AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.simonsoft.cms.indexing.abx;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+
+import se.repos.indexing.IndexingDoc;
+import se.repos.indexing.item.IndexingItemProgress;
+import se.repos.indexing.twophases.IndexingDocIncrementalSolrj;
+
+public class HandlerPathareaFromPropertiesTest {
+
+	@Test
+	public void testMasterProps() {
+		// Should identify Release/Translation based on Master-props.
+		IndexingDoc doc = new IndexingDocIncrementalSolrj();
+		IndexingItemProgress progress = mock(IndexingItemProgress.class);
+		when(progress.getFields()).thenReturn(doc);
+		HandlerPathareaFromProperties area = new HandlerPathareaFromProperties();
+		
+		area.handle(progress);
+		assertNull("Not a release or translation", doc.getFieldValues("patharea"));
+		assertEquals("Thus a 'main'", true, (Boolean) doc.getFieldValue("pathmain"));
+		
+		// Having only AuthorMaster is an undefined situation.
+		doc.addField("prop_abx.AuthorMaster", "x-svn:///svn/demo1^/vvab/xml/Documents/900108.xml?p=100");
+		doc.addField("prop_abx.ReleaseMaster", "x-svn:///svn/demo1^/vvab/xml/Documents/900108.xml?p=100");
+		area.handle(progress);
+		assertNotNull("Should have identified area", doc.getFieldValues("patharea"));
+		assertEquals("Authormaster and ReleaseMaster", "release", doc.getFieldValues("patharea").iterator().next());
+		assertEquals("Thus no longer author area", false, (Boolean) doc.getFieldValue("pathmain"));
+		
+		// Having only both RM and TM is an undefined situation.
+		doc.removeField("prop_abx.ReleaseMaster");
+		doc.addField("prop_abx.TranslationMaster", "x-svn:///svn/demo1^/vvab/xml/Documents/900108.xml?p=100");
+		doc.removeField("patharea");
+		area.handle(progress);
+		assertNotNull("Should have identified area", doc.getFieldValues("patharea"));
+		assertEquals("Has translation master", "translation", doc.getFieldValues("patharea").iterator().next());
+		assertEquals("No longer relase", 1, doc.getFieldValues("patharea").size());
+		assertEquals("Also not author area", false, (Boolean) doc.getFieldValue("pathmain"));
+	}
+	
+	@Test
+	public void testLabelProps() {
+		// Should identify Release/Translation based on Label/Locale-props.
+		IndexingDoc doc = new IndexingDocIncrementalSolrj();
+		IndexingItemProgress progress = mock(IndexingItemProgress.class);
+		when(progress.getFields()).thenReturn(doc);
+		HandlerPathareaFromProperties area = new HandlerPathareaFromProperties();
+		
+		area.handle(progress);
+		assertNull("Not a release or translation", doc.getFieldValues("patharea"));
+		assertEquals("Thus a 'main'", true, (Boolean) doc.getFieldValue("pathmain"));
+		
+		doc.addField("prop_abx.ReleaseLabel", "X");
+		area.handle(progress);
+		assertNotNull("Should have identified area", doc.getFieldValues("patharea"));
+		assertEquals("Authormaster but no locale", "release", doc.getFieldValues("patharea").iterator().next());
+		assertEquals("Thus no longer author area", false, (Boolean) doc.getFieldValue("pathmain"));
+		
+		doc.addField("prop_abx.TranslationLocale", "pt-PT");
+		doc.removeField("patharea");
+		area.handle(progress);
+		assertNotNull("Should have identified area", doc.getFieldValues("patharea"));
+		assertEquals("Has translation master", "translation", doc.getFieldValues("patharea").iterator().next());
+		assertEquals("No longer relase", 1, doc.getFieldValues("patharea").size());
+		assertEquals("Also not author area", false, (Boolean) doc.getFieldValue("pathmain"));
+	}
+	
+	
+	@Test
+	public void testGraphicTranslated() {
+		IndexingDoc doc = new IndexingDocIncrementalSolrj();
+		IndexingItemProgress progress = mock(IndexingItemProgress.class);
+		when(progress.getFields()).thenReturn(doc);
+		HandlerPathareaFromProperties area = new HandlerPathareaFromProperties();
+		
+		area.handle(progress);
+		assertNull("Not a release or translation", doc.getFieldValues("patharea"));
+		assertEquals("Thus a 'main'", true, (Boolean) doc.getFieldValue("pathmain"));
+		
+		// Translated graphics did not exist in CMS 1.0.
+		doc.addField("prop_abx.AuthorMaster", "x-svn:///svn/demo1^/vvab/graphics/0005.tif?p=157");
+		doc.addField("prop_abx.TranslationMaster", "x-svn:///svn/demo1^/vvab/graphics/0005.tif?p=157");
+		doc.addField("prop_abx.TranslationLocale", "pt-PT");
+		doc.removeField("patharea");
+		area.handle(progress);
+		assertNotNull("Should have identified area", doc.getFieldValues("patharea"));
+		assertEquals("Also not author area", false, (Boolean) doc.getFieldValue("pathmain"));
+		assertEquals("Has translation master", "translation", doc.getFieldValues("patharea").iterator().next());
+		assertEquals("No longer relase", 1, doc.getFieldValues("patharea").size());
+
+	}
+	
+
+	@Test
+	public void testLegacyTranslations() {
+		IndexingDoc doc = new IndexingDocIncrementalSolrj();
+		IndexingItemProgress progress = mock(IndexingItemProgress.class);
+		when(progress.getFields()).thenReturn(doc);
+		HandlerPathareaFromProperties area = new HandlerPathareaFromProperties();
+		
+		area.handle(progress);
+		assertNull("Not a release or translation", doc.getFieldValues("patharea"));
+		assertEquals("Thus a 'main'", true, (Boolean) doc.getFieldValue("pathmain"));
+		
+		// translations created before the release concept don't have translation locale //doc.addField("prop_abx.TranslationLocale", "pt-PT");
+		doc.addField("prop_abx.TranslationMaster", "x-svn:///svn/repo1^/demo/Documents/Presentation_B.xml?p=45");
+		doc.removeField("patharea");
+		area.handle(progress);
+		assertNotNull("Should have identified area", doc.getFieldValues("patharea"));
+		assertEquals("Has translation master", "translation10", doc.getFieldValues("patharea").iterator().next());
+		assertEquals("No longer relase", 1, doc.getFieldValues("patharea").size());
+		assertEquals("Also not author area", false, (Boolean) doc.getFieldValue("pathmain"));
+		
+	}	
+	
+}

--- a/src/test/java/se/simonsoft/cms/indexing/abx/HandlerTextSelectionTest.java
+++ b/src/test/java/se/simonsoft/cms/indexing/abx/HandlerTextSelectionTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2009-2013 Simonsoft Nordic AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.simonsoft.cms.indexing.abx;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import se.repos.indexing.IndexingDoc;
+import se.repos.indexing.item.IndexingItemProgress;
+import se.repos.indexing.twophases.IndexingDocIncrementalSolrj;
+
+public class HandlerTextSelectionTest {
+	
+	
+	@Test
+	public void shouldIndexXmlField() {
+		IndexingItemProgress progress = mock(IndexingItemProgress.class);
+		IndexingDoc doc = new IndexingDocIncrementalSolrj();
+		doc.setField("text", "tika");
+		doc.setField("embd_xml_text", "xml");
+		
+		when(progress.getFields()).thenReturn(doc);
+		
+		HandlerTextSelection handler = new HandlerTextSelection();
+		handler.handle(progress);
+		
+		assertEquals("xml", doc.getFieldValue("text"));
+		assertNull("should remove the xml field", doc.getFieldValue("embd_xml_text"));
+	}
+	
+}

--- a/src/test/java/se/simonsoft/cms/indexing/abx/HandlerTitleSelectionTest.java
+++ b/src/test/java/se/simonsoft/cms/indexing/abx/HandlerTitleSelectionTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2009-2013 Simonsoft Nordic AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package se.simonsoft.cms.indexing.abx;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import se.repos.indexing.IndexingDoc;
+import se.repos.indexing.item.IndexingItemProgress;
+import se.repos.indexing.twophases.IndexingDocIncrementalSolrj;
+
+public class HandlerTitleSelectionTest {
+	
+	
+	@Test
+	public void shouldIndexKeyValueWithHighestPrio() {
+		IndexingItemProgress progress = mock(IndexingItemProgress.class);
+		IndexingDoc doc = new IndexingDocIncrementalSolrj();
+		doc.setField("xmp_dc.title", "xmp dc title");
+		doc.setField("embd_title", "embd title");
+		doc.setField("xmp_dc.subject", "xmp dc subject");
+		
+		when(progress.getFields()).thenReturn(doc);
+		
+		HandlerTitleSelection handler = new HandlerTitleSelection();
+		handler.handle(progress);
+		
+		assertEquals("embd title", doc.getFieldValue("title"));
+		
+	}
+	
+}

--- a/src/test/resources/se/simonsoft/cms/indexing/emptyfileextrarevprop.svndump
+++ b/src/test/resources/se/simonsoft/cms/indexing/emptyfileextrarevprop.svndump
@@ -1,0 +1,52 @@
+SVN-fs-dump-format-version: 2
+
+UUID: d7dc4516-ae4c-4702-95c6-6a5720a1bf52
+
+Revision-number: 0
+Prop-content-length: 92
+Content-length: 92
+
+K 14
+custom:revprop
+V 10
+Prop value
+K 8
+svn:date
+V 27
+2012-10-22T09:36:22.234766Z
+PROPS-END
+
+Revision-number: 1
+Prop-content-length: 136
+Content-length: 136
+
+K 10
+svn:author
+V 7
+solsson
+K 8
+svn:date
+V 27
+2012-10-22T09:37:55.290780Z
+K 7
+svn:log
+V 34
+Added empty file, will set revprop
+PROPS-END
+
+Node-path: emptyfile.txt
+Node-kind: file
+Node-action: add
+Prop-content-length: 45
+Text-content-length: 0
+Text-content-md5: d41d8cd98f00b204e9800998ecf8427e
+Text-content-sha1: da39a3ee5e6b4b0d3255bfef95601890afd80709
+Content-length: 45
+
+K 13
+svn:mime-type
+V 10
+text/plain
+PROPS-END
+
+


### PR DESCRIPTION
The separation was intended to represent responsibility for different solr cores, but now cms-indexing-xml deals with both repositem and reposxml. Hence the merge, that keeps pom.xml from cms-indexing-xml.

Done this way:
```
git remote add cms-indexing https://github.com/Simonsoft/cms-indexing
git fetch cms-indexing
git checkout cms-indexing/master
git checkout -b cms-indexing
git filter-branch --index-filter 'git rm --cached --ignore-unmatch pom.xml' cms-indexing
git filter-branch --index-filter 'git rm --cached --ignore-unmatch LICENSE' -f cms-indexing
git checkout master
git checkout -b merge-cms-indexing
git merge --no-ff cms-indexing
```
After that I added https://github.com/simonsoft/cms-indexing-xml/pull/1/commits/3a2ba192cba6fab0a426541632b9ebde529affd0.

I haven't run any tests yet.