### PR TITLE
Solr upgradability to 8.x

### DIFF
--- a/src/main/resources/se/simonsoft/cms/indexing/xml/solr/reposxml/conf/schema.xml
+++ b/src/main/resources/se/simonsoft/cms/indexing/xml/solr/reposxml/conf/schema.xml
@@ -244,11 +244,6 @@
 	<!-- field to use to determine and enforce document uniqueness. -->
 	<uniqueKey>id</uniqueKey>
 
-	<!-- field for the QueryParser to use when an explicit fieldname is absent -->
-	<defaultSearchField>name</defaultSearchField>
-
-	<!-- SolrQueryParser configuration: defaultOperator="AND|OR" -->
-	<solrQueryParser defaultOperator="OR" />
 	
 	<types>	
 		<fieldtype name="string" class="solr.StrField" sortMissingLast="true" omitNorms="true" />
@@ -284,7 +279,6 @@
 		<fieldType class="solr.TextField" name="text_spell" positionIncrementGap="100">
 			<analyzer>
 				<tokenizer class="solr.StandardTokenizerFactory" />
-				<filter class="solr.StandardFilterFactory" />
 				<filter class="solr.LowerCaseFilterFactory" />
 			</analyzer>
 		</fieldType>	

--- a/src/main/resources/se/simonsoft/cms/indexing/xml/solr/reposxml/conf/solrconfig.xml
+++ b/src/main/resources/se/simonsoft/cms/indexing/xml/solr/reposxml/conf/solrconfig.xml
@@ -17,16 +17,14 @@
 
 -->
 <config>
-  <luceneMatchVersion>LUCENE_40</luceneMatchVersion>
+  <luceneMatchVersion>6.6.6</luceneMatchVersion>
   <!--  The DirectoryFactory to use for indexes.
         solr.StandardDirectoryFactory, the default, is filesystem based.
         solr.RAMDirectoryFactory is memory based, not persistent, and doesn't work with replication. -->
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.StandardDirectoryFactory}"/>
 
-  <!-- Likely need to add ClassicIndexSchemaFactory when upgrading luceneMatchVersion to 6.0. -->
-  <!-- 
+  <!-- ClassicIndexSchemaFactory requires the use of a schema.xml configuration file, and disallows any programatic changes to the Schema at run time. -->
   <schemaFactory class="ClassicIndexSchemaFactory"/>
-  -->
 
   <dataDir>${solr.reposxml.data.dir:}</dataDir>
 
@@ -57,15 +55,7 @@
   <!-- AdminHandlers not present in SolR 6 
   <requestHandler name="/admin/" class="org.apache.solr.handler.admin.AdminHandlers" />
   -->
-     
-  <requestHandler name="/admin/ping" class="solr.PingRequestHandler">
-    <lst name="invariants">
-      <str name="q">solrpingquery</str>
-    </lst>
-    <lst name="defaults">
-      <str name="echoParams">all</str>
-    </lst>
-  </requestHandler>
+
    
   <!-- config for the admin interface --> 
   <admin>


### PR DESCRIPTION
 - Lucene match updated to 6.6.6.
 - Removed desupported config